### PR TITLE
Fix AWS SDK for Ruby installing doc

### DIFF
--- a/doc_source/setup-install.rst
+++ b/doc_source/setup-install.rst
@@ -40,7 +40,7 @@ to add the |sdk-ruby| to your project.
 
 .. code-block:: none
 
-    gem aws-sdk
+    gem 'aws-sdk'
 
 If you don't use Bundler, the easiest way to install the SDK is to use `RubyGems
 <https://rubygems.org/gems/aws-sdk/>`_. To install the latest version of the SDK, use the following


### PR DESCRIPTION
Bundler uses standard Ruby syntax in `Gemfile`. 
`gem aws-sdk` is not correct Ruby.