### PR TITLE
Point to correct gem for aws-v3.rb.

### DIFF
--- a/doc_source/repl.rst
+++ b/doc_source/repl.rst
@@ -21,7 +21,7 @@ Using the |sdk-ruby| REPL Tool
     :keywords: AWS SDK for ruby, aws.rb, aws-v3.rb, aws-sdk-core gem, ruby code examples
 
 Developers can use :code:`aws-v3.rb` (formerly :code:`aws.rb`), the interactive command line
-read-evaluate-print loop (REPL) console tool that is part of the :code:`aws-sdk-core` gem.
+read-evaluate-print loop (REPL) console tool that is part of the :code:`aws-sdk` gem.
 
 Although :code:`aws-v3.rb` does work with the Interactive Ruby Shell (:code:`irb`), we recommend that
 you install :code:`pry`, which provides a more powerful REPL environment.


### PR DESCRIPTION
The docs incorrectly suggest that `aws-sdk-core` contains `aws-v3.rb`.

Technically, this REPL lives in `aws-sdk-resources`, but given it has a dependency on all of the other
SDK gems, it's probably best to suggest the parent gem, `aws-sdk`. This is also consistent with
other documentation at https://docs.aws.amazon.com/sdk-for-ruby/v3/api/#REPL_-_AWS_Interactive_Console.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
