### PR TITLE
Update dynamo-example-load-table-items-from-json.rst

### DIFF
--- a/doc_source/dynamo-example-load-table-items-from-json.rst
+++ b/doc_source/dynamo-example-load-table-items-from-json.rst
@@ -32,6 +32,6 @@ Here is an example of a JSON file that loads two movies.
    :dedent: 0
    :language: json
 
-See the `complete example <https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/ruby/dynamodb/dynamodb_ruby_example_load_movies.rb>`_
-and the `JSON file <https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/ruby/dynamodb/movie_data.json>`_
+See the `complete example <https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/ruby/example_code/dynamodb/dynamodb_ruby_example_load_movies.rb>`_
+and the `JSON file <https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/ruby/example_code/dynamodb/movie_data.json>`_
 on GitHub.


### PR DESCRIPTION
Correct URL references to point to the correct location on github from the aws docs page.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
