### PR TITLE
Fix broken links

### DIFF
--- a/doc_source/kms-example-create-key.md
+++ b/doc_source/kms-example-create-key.md
@@ -37,4 +37,4 @@ resp = client.create_key({
 puts resp.key_metadata.key_id
 ```
 
-Choose `Copy` to save the code locally\. See the [complete example](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/ruby/kms/aws-ruby-sdk-kms-example-create-key.rb) on GitHub\.
+Choose `Copy` to save the code locally\. See the [complete example](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/ruby/example_code/kms/create_key.rb) on GitHub\.

--- a/doc_source/kms-example-decrypt-blob.md
+++ b/doc_source/kms-example-decrypt-blob.md
@@ -32,4 +32,4 @@ puts 'Raw text: '
 puts resp.plaintext
 ```
 
-Choose `Copy` to save the code locally\. See the [complete example](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/ruby/kms/aws-ruby-sdk-kms-example-decrypt-blob.rb) on GitHub\.
+Choose `Copy` to save the code locally\. See the [complete example](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/ruby/example_code/kms/decrypt_data.rb) on GitHub\.

--- a/doc_source/kms-example-encrypt-data.md
+++ b/doc_source/kms-example-encrypt-data.md
@@ -36,4 +36,4 @@ puts 'Blob:'
 puts resp.ciphertext_blob.unpack('H*')
 ```
 
-Choose `Copy` to save the code locally\. See the [complete example](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/ruby/kms/aws-ruby-sdk-kms-example-encrypt-data.rb) on GitHub\.
+Choose `Copy` to save the code locally\. See the [complete example](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/ruby/example_code/kms/encrypt_data.rb) on GitHub\.

--- a/doc_source/kms-example-re-encrypt-data.md
+++ b/doc_source/kms-example-re-encrypt-data.md
@@ -37,4 +37,4 @@ puts 'Blob:'
 puts resp.ciphertext_blob.unpack('H*')
 ```
 
-Choose `Copy` to save the code locally\. See the [complete example](https://github.com/awsdocs/aws-doc-sdk-examples/blob/master/ruby/kms/aws-ruby-sdk-kms-example-re-encrypt-data.rb) on GitHub\.
+Choose `Copy` to save the code locally\. See the [complete example](https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/ruby/example_code/kms/re_encrypt_data.rb) on GitHub\.


### PR DESCRIPTION
*Description of changes:*

Hi, I found some broken links while looking through [AWS KMS Examples docs](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/kms-examples.html).
The links to `complete example on GitHub` in the following pages are outdated:
- [Creating an AWS KMS key](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/kms-example-create-key.html)
- [Encrypting Data in AWS KMS](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/kms-example-encrypt-data.html)
- [Decrypting a Data Blob in AWS KMS](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/kms-example-decrypt-blob.html)
- [Re-encrypting a Data Blob in AWS KMS](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/kms-example-re-encrypt-data.html)

This pull request fixes broken links to correct examples. 🙂 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
